### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,33 +1,20 @@
+---
 schema: '2.0'
 stages:
   download_sqlite:
     cmd: Rscript stages/1_build.R
     deps:
-    - path: staging/checksums.txt
-      md5: 5cc06d32fa75420849b207a648072994
+    - md5: 5cc06d32fa75420849b207a648072994
+      path: staging/checksums.txt
       size: 790
     outs:
-    - path: brick/
-      md5: a782c8a6650e9022c754f793f1b1a464.dir
+    - md5: a782c8a6650e9022c754f793f1b1a464.dir
+      nfiles: 81
+      path: brick/
       size: 2601302054
-      nfiles: 81
-  build_parquet:
-    cmd: Rscript R/build_parquet.R
-    deps:
-    - path: R/build_parquet.R
-      md5: 20c7cfd5d5e0539deefacc7a1d045998
-      size: 466
-    - path: data/chembl_30.db
-      md5: 755388412e0c22a93cff2314bbdc5f7a
-      size: 22373666816
-    outs:
-    - path: data/parquet
-      md5: 297e3b999350ecc23ce39cd83a6b2bb0.dir
-      size: 2429176712
-      nfiles: 81
   invalidate:
     cmd: Rscript stages/0_invalidate.R
     outs:
-    - path: staging/checksums.txt
-      md5: 5cc06d32fa75420849b207a648072994
+    - md5: 5cc06d32fa75420849b207a648072994
+      path: staging/checksums.txt
       size: 790


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
